### PR TITLE
fix https://github.com/doczhcn/istio/issues/7 delete tag plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -20,8 +20,7 @@
     "wide-page",
     "page-toc-button",
     "back-to-top-button",
-    "page-footer-ex",
-    "tags"
+    "page-footer-ex"
   ],
   "pluginsConfig": {
     "edit-link": {


### PR DESCRIPTION
Delete gitbook tags plugin to boost the webpage loading speed.